### PR TITLE
Add users to group chat based on telegram id

### DIFF
--- a/src/shout_subgroup/group_chat_listener.py
+++ b/src/shout_subgroup/group_chat_listener.py
@@ -11,8 +11,8 @@ from shout_subgroup.repository import (
     find_all_subgroups_in_group_chat,
     find_users_by_usernames,
     find_group_chat_by_telegram_group_chat_id,
-    insert_user,
-    insert_group_chat
+    insert_group_chat,
+    add_user_to_group_chat as add_user_to_group_chat_repo
 )
 from shout_subgroup.utils import is_group_chat
 from shout_subgroup.remove_subgroup_members import remove_users_from_existing_subgroup
@@ -26,24 +26,17 @@ async def add_user_to_group_chat(db: Session, chat: Chat, current_user: UserMode
         logging.info(msg)
         raise NotGroupChatError(msg)
 
+    # Check if the group chat exists in our system, if not we need to add it
     group_chat = await find_group_chat_by_telegram_group_chat_id(db, chat.id)
-
     if not group_chat:
         group_chat = await insert_group_chat(db, chat.id, chat.title, chat.description)
 
+    # Add the user to the group chat if they're not already in it
     all_users = await find_all_users_in_group_chat(db, chat.id)
+    telegram_user_ids_in_group_chat = {user.telegram_user_id for user in all_users}
 
-    # Telegram usernames are case-insensitive,
-    # but we're lowercasing these for consistency in string comparisons
-    usernames_in_group_chat = [user.username.lower() for user in all_users]
-    if current_user.username.lower() not in usernames_in_group_chat:
-        added_user = await insert_user(db, current_user.user_id, current_user.username, current_user.first_name,
-                                       current_user.last_name)
-        group_chat.users.append(added_user)
-        db.add(group_chat)
-        db.commit()
-        db.refresh(added_user)
-        return added_user
+    if current_user.telegram_user_id not in telegram_user_ids_in_group_chat:
+        return await add_user_to_group_chat_repo(db, group_chat, current_user)
 
     return None
 
@@ -79,15 +72,28 @@ async def remove_user_from_all_group_chat_sub_groups(db: Session, telegram_group
 
 
 async def listen_for_messages_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    session = get_database()
-    current_user = UserModel(
+    """
+    Handles listening to messages sent by users.
+
+    The handler listens to messages, then adds sender of the message to
+    the group chat table if they do not exist.
+
+    This is needed b/c the system requires data about the members in a group chat
+    in order to reference them.
+    :param update:
+    :param context:
+    :return:
+    """
+    user_who_sent_the_message = UserModel(
         telegram_user_id=update.message.from_user.id,
         username=update.message.from_user.username,
         first_name=update.message.from_user.first_name,
-        last_name=update.message.from_user.last_name)
+        last_name=update.message.from_user.last_name
+    )
 
+    session = get_database()
     try:
-        maybe_added_user = await add_user_to_group_chat(session, update.effective_chat, current_user)
+        maybe_added_user = await add_user_to_group_chat(session, update.effective_chat, user_who_sent_the_message)
         # TODO: Add message like "The bot has recognized John Doe"
         return
     except NotGroupChatError:

--- a/src/shout_subgroup/repository.py
+++ b/src/shout_subgroup/repository.py
@@ -117,15 +117,16 @@ async def find_group_chat_by_telegram_group_chat_id(db: Session, telegram_group_
     result = db.execute(stmt).scalars().first()
     return result
 
+
 async def insert_user(
         db: Session,
-        user_id: int,
+        telegram_user_id: int,
         username: str,
         first_name: str,
         last_name: str
 ) -> UserModel:
     new_user = UserModel(
-        telegram_user_id=user_id,
+        telegram_user_id=telegram_user_id,
         username=username,
         first_name=first_name,
         last_name=last_name
@@ -265,3 +266,26 @@ async def add_users_to_subgroup(db: Session, subgroup: SubgroupModel, user_ids: 
     db.refresh(subgroup)
 
     return subgroup
+
+
+async def add_user_to_group_chat(db: Session, group_chat: GroupChatModel, current_user: UserModel):
+    """
+    Adds a user to an existing group chat.
+    It's the callers responsibility to check
+    if the group chat exists
+    :param db:
+    :param group_chat:
+    :param current_user:
+    :return:
+    """
+    added_user = await insert_user(
+        db,
+        current_user.telegram_user_id,
+        current_user.username,
+        current_user.first_name,
+        current_user.last_name
+    )
+    group_chat.users.append(added_user)
+    db.commit()
+    db.refresh(added_user)
+    return added_user

--- a/tests/test_group_chat_listener.py
+++ b/tests/test_group_chat_listener.py
@@ -21,32 +21,41 @@ async def test_add_user_if_not_in_group_chat(db: Session):
     telegram_group_chat_description = "Test Chatting"
 
     initial_group_chat_users = [john, jane]
-    group_chat = create_test_group_chat(db, telegram_group_chat_id, telegram_group_chat_name, initial_group_chat_users)
-
-    # But: The user is not in the group chat
-    betty = Mock()
-    betty.user_id = 87654
-    betty.username = "betty"
-    betty.first_name = "Betty"
-    betty.last_name = "White"
+    group_chat = create_test_group_chat(
+        db,
+        telegram_group_chat_id,
+        telegram_group_chat_name,
+        initial_group_chat_users,
+        telegram_group_chat_description
+    )
 
     telegram_chat = Mock()
     telegram_chat.id = telegram_group_chat_id
     telegram_chat.title = telegram_group_chat_name
     telegram_chat.description = telegram_group_chat_description
 
+    # But: The user is not in the group chat
+    current_user = UserModel(
+        telegram_user_id=87654,
+        username="betty",
+        first_name="Betty",
+        last_name="White"
+    )
+
     # When: The listener determines this
-    added_user = await add_user_to_group_chat(db, telegram_chat, betty)
+    added_user = await add_user_to_group_chat(db, telegram_chat, current_user)
 
     # Then: The user should be added to the group chat
     assert len(group_chat.users) == 3
 
     assert added_user.user_id is not None
 
-    actual_user = next((user for user in group_chat.users if user.username == betty.username), None)
+    actual_user = next((user for user in group_chat.users if user.telegram_user_id == current_user.telegram_user_id),
+                       None)
+    assert actual_user.telegram_user_id == added_user.telegram_user_id
+    assert actual_user.username == added_user.username
     assert actual_user.first_name == added_user.first_name
     assert actual_user.last_name == added_user.last_name
-    assert actual_user.telegram_user_id == added_user.telegram_user_id
 
 
 @pytest.mark.asyncio
@@ -60,16 +69,25 @@ async def test_ignore_user_if_already_in_group_chat(db: Session):
     telegram_group_chat_description = "Test Chatting"
 
     initial_group_chat_users = [john, jane]
-    group_chat = create_test_group_chat(db, telegram_group_chat_id, telegram_group_chat_name, initial_group_chat_users)
+    create_test_group_chat(
+        db,
+        telegram_group_chat_id,
+        telegram_group_chat_name,
+        initial_group_chat_users,
+        telegram_group_chat_description
+    )
 
-    # But: The user is already in the group chat
     telegram_chat = Mock()
     telegram_chat.id = telegram_group_chat_id
     telegram_chat.title = telegram_group_chat_name
     telegram_chat.description = telegram_group_chat_description
 
+    # But: The user is already in the group chat
+    existing_user = john
+
     # When: The listener determines this
-    added_user = await add_user_to_group_chat(db, telegram_chat, john)
+    added_user = await add_user_to_group_chat(db, telegram_chat, existing_user)
+
     # Then: The user should not be added to the group chat
     assert added_user is None
 
@@ -77,32 +95,42 @@ async def test_ignore_user_if_already_in_group_chat(db: Session):
 @pytest.mark.asyncio
 async def test_create_group_chat_and_add_user_if_both_non_existent(db: Session):
     # Given: A group chat doesn't exists
-    john = create_test_user(db, telegram_user_id=12345, username="johndoe", first_name="John", last_name="Doe")
-    jane = create_test_user(db, telegram_user_id=67890, username="janedoe", first_name="Jane", last_name="Doe")
-
     telegram_group_chat_id = -123456789
     telegram_group_chat_name = "Group Chat"
     telegram_group_chat_description = "Test Chatting"
-    # And: We don't have a user
+
     telegram_chat = Mock()
     telegram_chat.id = telegram_group_chat_id
     telegram_chat.title = telegram_group_chat_name
     telegram_chat.description = telegram_group_chat_description
 
-    current_user = Mock()
-    current_user.user_id = 98765
-    current_user.username = "mary"
-    current_user.first_name = "Mary"
-    current_user.last_name = "Lynn"
+    # And: The user isn't in the group chat
+    current_user = UserModel(
+        telegram_user_id=87654,
+        username="betty",
+        first_name="Betty",
+        last_name="White"
+    )
 
-    # When: The listener determines this
+    # When: We add the user to the non-existent group chat
     added_user = await add_user_to_group_chat(db, telegram_chat, current_user)
 
-    # Then: The group chat is created and the user is added
+    # Then: The group chat is created
     created_group_chat = await find_group_chat_by_telegram_group_chat_id(db, telegram_group_chat_id)
-    assert created_group_chat is not None
+    assert created_group_chat.group_chat_id is not None
+    assert created_group_chat.telegram_group_chat_id == telegram_group_chat_id
+    assert created_group_chat.name == telegram_group_chat_name
+    assert created_group_chat.description == telegram_group_chat_description
 
-    actual_user = next((user for user in created_group_chat.users if user.username == current_user.username), None)
+    # And: The user was added
+    actual_user = next(
+        (
+            user
+            for user in created_group_chat.users
+            if user.telegram_user_id == current_user.telegram_user_id
+        ), None
+    )
+    assert actual_user.user_id is not None
     assert actual_user.first_name == added_user.first_name
     assert actual_user.last_name == added_user.last_name
     assert actual_user.telegram_user_id == added_user.telegram_user_id
@@ -116,35 +144,34 @@ async def test_add_user_to_group_throws_exception_for_non_group_chat(db: Session
 
     telegram_group_chat_id = -123456789
     telegram_group_chat_name = "Group Chat"
-    telegram_group_chat_description = "Test Chatting"
 
     initial_group_chat_users = [john, jane]
     group_chat = create_test_group_chat(db, telegram_group_chat_id, telegram_group_chat_name, initial_group_chat_users)
 
-    # But: The user is not in the group chat and the chat is not a group chat
-    betty = UserModel(
+    # But: The user is not in the group chat
+    current_user = UserModel(
         telegram_user_id=87654,
         username="betty",
         first_name="Betty",
         last_name="White"
     )
 
+    # And: the intended chat is not a group chat
     not_telegram_group_chat_id = 123456789
-
     telegram_chat = Mock()
     telegram_chat.id = not_telegram_group_chat_id
     telegram_chat.title = ""
     telegram_chat.description = ""
 
-    # When: The listener determines this
-
-    # When: We try to add the user to a not group chat
+    # When: We try to add the user to a non-group chat
     with pytest.raises(NotGroupChatError) as ex:
-        added_user = await add_user_to_group_chat(db, telegram_chat, betty)
+        await add_user_to_group_chat(db, telegram_chat, current_user)
 
     # Then: The exception is thrown with correct message and the user was not added 
     assert str(not_telegram_group_chat_id) in ex.value.message
-    actual_user = next((user for user in group_chat.users if user.username == betty.username), None)
+
+    # And: Other group chats are not impacted
+    actual_user = next((user for user in group_chat.users if user.username == current_user.username), None)
     assert actual_user is None
 
 
@@ -197,7 +224,6 @@ async def test_remove_user_from_group_chat(db: Session):
 
 @pytest.mark.asyncio
 async def test_remove_user_from_group_chat_if_not_in_group_chat(db: Session):
-
     # Given: A group chat exists
     john = create_test_user(db, telegram_user_id=12345, username="johndoe", first_name="John", last_name="Doe")
     jane = create_test_user(db, telegram_user_id=67890, username="janedoe", first_name="Jane", last_name="Doe")


### PR DESCRIPTION
Instead of using usernames, we're using
telegram user ids. We did this b/c not all
Telegram users have a username, but they
will have a telegram id.

fixes #40